### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/demo/dataviewer.py
+++ b/demo/dataviewer.py
@@ -78,7 +78,7 @@ class DataViewer(webapp.RequestHandler):
         results, cursor, more = query.fetch_page(page_size,
                                                  start_cursor=cursor)
       except Exception, err:
-        params['error'] = '%s error: %s.%s: %s' % (prefix,
+        params['error'] = '{0!s} error: {1!s}.{2!s}: {3!s}'.format(prefix,
                                                    err.__class__.__module__,
                                                    err.__class__.__name__,
                                                    err)
@@ -104,7 +104,7 @@ class DataViewer(webapp.RequestHandler):
           data.append('<tr>')
           columns = ['__key__'] + sorted(columns)
           for col in columns:
-            data.append('  <th>%s</th>' % cgi.escape(col))
+            data.append('  <th>{0!s}</th>'.format(cgi.escape(col)))
           data.append('</tr>')
           data.append('</thead>')
           data.append('<tbody>')
@@ -114,17 +114,17 @@ class DataViewer(webapp.RequestHandler):
               if col not in row:
                 data.append('  <td></td>')
               else:
-                data.append('  <td>%s</td>' % cgi.escape(row[col]))
+                data.append('  <td>{0!s}</td>'.format(cgi.escape(row[col])))
             data.append('</tr>')
           data.append('</tbody>')
           data.append('</table>')
           params['data'] = '\n    '.join(data)
           if more:
-            next = ('<a href=/dataviewer?%s>Next</a>' %
+            next = ('<a href=/dataviewer?{0!s}>Next</a>'.format(
                     urllib.urlencode([('query', query_string),
                                       ('cursor', cursor.to_websafe_string()),
                                       ('page', page_size),
-                                      ]))
+                                      ])))
             params['next'] = next
     self.response.out.write(FORM % params)
 

--- a/demo/fibo.py
+++ b/demo/fibo.py
@@ -86,8 +86,7 @@ class FiboHandler(webapp.RequestHandler):
       memo_type = ''
       ans = yield fibonacci(num)
     t1 = time.time()
-    self.response.out.write('%sfibonacci(%d) == %d # computed in %.3f\n' %
-                            (memo_type, num, ans, t1 - t0))
+    self.response.out.write('{0!s}fibonacci({1:d}) == {2:d} # computed in {3:.3f}\n'.format(memo_type, num, ans, t1 - t0))
 
 
 urls = [

--- a/demo/guestbook.py
+++ b/demo/guestbook.py
@@ -42,19 +42,19 @@ class MainPage(webapp.RequestHandler):
     greetings = Greeting.QueryBook(ancestor_key)
 
     for greeting in greetings:
-      self.response.out.write('<blockquote>%s</blockquote>' %
-                              cgi.escape(greeting.content))
+      self.response.out.write('<blockquote>{0!s}</blockquote>'.format(
+                              cgi.escape(greeting.content)))
 
     self.response.out.write("""
-          <form action="/sign?%s" method="post">
+          <form action="/sign?{0!s}" method="post">
             <div><textarea name="content" rows="3" cols="60"></textarea></div>
             <div><input type="submit" value="Sign Guestbook"></div>
           </form>
           <hr>
-          <form>Guestbook name: <input value="%s" name="guestbook_name">
+          <form>Guestbook name: <input value="{1!s}" name="guestbook_name">
           <input type="submit" value="switch"></form>
         </body>
-      </html>""" % (urllib.urlencode({'guestbook_name': guestbook_name}),
+      </html>""".format(urllib.urlencode({'guestbook_name': guestbook_name}),
                     cgi.escape(guestbook_name)))
 
 

--- a/demo/main.py
+++ b/demo/main.py
@@ -176,11 +176,11 @@ class HomePage(webapp.RequestHandler):
           yield summary.put_async()
       hover = ''
       if summary.title:
-        hover = ' title="%s"' % summary.title
+        hover = ' title="{0!s}"'.format(summary.title)
       escbody = (cgi.escape(pre) +
-                 '<a%s href="%s">' % (hover, cgi.escape(url)) +
+                 '<a{0!s} href="{1!s}">'.format(hover, cgi.escape(url)) +
                  cgi.escape(url) + '</a>' + cgi.escape(post))
-    text = '%s - %s - %s<br>' % (cgi.escape(nickname),
+    text = '{0!s} - {1!s} - {2!s}<br>'.format(cgi.escape(nickname),
                                  time.ctime(message.when or 0),
                                  escbody)
     if message.when is None:

--- a/demo/shell.py
+++ b/demo/shell.py
@@ -41,10 +41,10 @@ def shell():
   project_id = id_resolver.resolve_project_id(application_id)
 
   banner = """ndb shell
-  Python %s
-  Project: %s
+  Python {0!s}
+  Project: {1!s}
   The ndb module is already imported.
-  """ % (sys.version, project_id)
+  """.format(sys.version, project_id)
 
   imports = {
     'ndb': ndb,
@@ -53,7 +53,7 @@ def shell():
   # set up the environment
   os.environ['SERVER_SOFTWARE'] = 'Development (ndb_shell)/0.1'
 
-  sys.ps1 = '%s> ' % project_id
+  sys.ps1 = '{0!s}> '.format(project_id)
   if readline is not None:
     # set up readline
     readline.parse_and_bind('tab: complete')

--- a/ndb/blobstore.py
+++ b/ndb/blobstore.py
@@ -182,7 +182,7 @@ class BlobInfo(model.Model):
   def get_async(cls, blob_key, **ctx_options):
     """Async version of get()."""
     if not isinstance(blob_key, (BlobKey, basestring)):
-      raise TypeError('Expected blob key, got %r' % (blob_key,))
+      raise TypeError('Expected blob key, got {0!r}'.format(blob_key))
     if 'parent' in ctx_options:
       raise TypeError('Parent is not supported')
     return cls.get_by_id_async(str(blob_key), **ctx_options)
@@ -206,7 +206,7 @@ class BlobInfo(model.Model):
     """Async version of get_multi()."""
     for blob_key in blob_keys:
       if not isinstance(blob_key, (BlobKey, basestring)):
-        raise TypeError('Expected blob key, got %r' % (blob_key,))
+        raise TypeError('Expected blob key, got {0!r}'.format(blob_key))
     if 'parent' in ctx_options:
       raise TypeError('Parent is not supported')
     blob_key_strs = map(str, blob_keys)
@@ -273,7 +273,7 @@ def delete(blob_key, **options):
 def delete_async(blob_key, **options):
   """Async version of delete()."""
   if not isinstance(blob_key, (basestring, BlobKey)):
-    raise TypeError('Expected blob key, got %r' % (blob_key,))
+    raise TypeError('Expected blob key, got {0!r}'.format(blob_key))
   rpc = blobstore.create_rpc(**options)
   yield blobstore.delete_async(blob_key, rpc=rpc)
 
@@ -293,7 +293,7 @@ def delete_multi(blob_keys, **options):
 def delete_multi_async(blob_keys, **options):
   """Async version of delete_multi()."""
   if isinstance(blob_keys, (basestring, BlobKey)):
-    raise TypeError('Expected a list, got %r' % (blob_key,))
+    raise TypeError('Expected a list, got {0!r}'.format(blob_key))
   rpc = blobstore.create_rpc(**options)
   yield blobstore.delete_async(blob_keys, rpc=rpc)
 
@@ -366,7 +366,7 @@ def parse_blob_info(field_storage):
     value = dct.get(name, None)
     if value is None:
       raise BlobInfoParseError(
-          'Field %s has no %s.' % (field_name, name))
+          'Field {0!s} has no {1!s}.'.format(field_name, name))
     return value
 
   filename = get_value(field_storage.disposition_options, 'filename')
@@ -384,7 +384,7 @@ def parse_blob_info(field_storage):
     size = int(size)
   except (TypeError, ValueError):
     raise BlobInfoParseError(
-        '%s is not a valid value for %s size.' % (size, field_name))
+        '{0!s} is not a valid value for {1!s} size.'.format(size, field_name))
 
   try:
     creation = blobstore._parse_creation(creation_string, field_name)

--- a/ndb/context.py
+++ b/ndb/context.py
@@ -53,42 +53,42 @@ class ContextOptions(datastore_rpc.Configuration):
   def use_cache(value):
     if not isinstance(value, bool):
       raise datastore_errors.BadArgumentError(
-          'use_cache should be a bool (%r)' % (value,))
+          'use_cache should be a bool ({0!r})'.format(value))
     return value
 
   @datastore_rpc.ConfigOption
   def use_memcache(value):
     if not isinstance(value, bool):
       raise datastore_errors.BadArgumentError(
-          'use_memcache should be a bool (%r)' % (value,))
+          'use_memcache should be a bool ({0!r})'.format(value))
     return value
 
   @datastore_rpc.ConfigOption
   def use_datastore(value):
     if not isinstance(value, bool):
       raise datastore_errors.BadArgumentError(
-          'use_datastore should be a bool (%r)' % (value,))
+          'use_datastore should be a bool ({0!r})'.format(value))
     return value
 
   @datastore_rpc.ConfigOption
   def memcache_timeout(value):
     if not isinstance(value, (int, long)):
       raise datastore_errors.BadArgumentError(
-          'memcache_timeout should be an integer (%r)' % (value,))
+          'memcache_timeout should be an integer ({0!r})'.format(value))
     return value
 
   @datastore_rpc.ConfigOption
   def max_memcache_items(value):
     if not isinstance(value, (int, long)):
       raise datastore_errors.BadArgumentError(
-          'max_memcache_items should be an integer (%r)' % (value,))
+          'max_memcache_items should be an integer ({0!r})'.format(value))
     return value
 
   @datastore_rpc.ConfigOption
   def memcache_deadline(value):
     if not isinstance(value, (int, long)):
       raise datastore_errors.BadArgumentError(
-          'memcache_deadline should be an integer (%r)' % (value,))
+          'memcache_deadline should be an integer ({0!r})'.format(value))
     return value
 
 
@@ -122,8 +122,7 @@ def _make_ctx_options(ctx_options, config_cls=ContextOptions):
     translation = _OPTION_TRANSLATIONS.get(key)
     if translation:
       if translation in ctx_options:
-        raise ValueError('Cannot specify %s and %s at the same time' %
-                         (key, translation))
+        raise ValueError('Cannot specify {0!s} and {1!s} at the same time'.format(key, translation))
       ctx_options[translation] = ctx_options.pop(key)
   return config_cls(**ctx_options)
 
@@ -176,7 +175,7 @@ class AutoBatcher(object):
     self._cache = {}  # Cache of in-flight todo_tasklet futures.
 
   def __repr__(self):
-    return '%s(%s)' % (self.__class__.__name__, self._todo_tasklet.__name__)
+    return '{0!s}({1!s})'.format(self.__class__.__name__, self._todo_tasklet.__name__)
 
   def run_queue(self, options, todo):
     """Actually run the _todo_tasklet."""
@@ -208,7 +207,7 @@ class AutoBatcher(object):
       An instance of future, representing the result of running
         _todo_tasklet without batching.
     """
-    fut = tasklets.Future('%s.add(%s, %s)' % (self, arg, options))
+    fut = tasklets.Future('{0!s}.add({1!s}, {2!s})'.format(self, arg, options))
     todo = self._queues.get(options)
     if todo is None:
       utils.logging_debug('AutoBatcher(%s): creating new queue for %r',
@@ -979,7 +978,7 @@ class Context(object):
               'Context without non-transactional ancestor')
     else:
       raise datastore_errors.BadArgumentError(
-          'Invalid propagation value (%s).' % (propagation,))
+          'Invalid propagation value ({0!s}).'.format(propagation))
 
     app = TransactionOptions.app(options) or key_module._DefaultAppId()
     # Note: zero retries means try it once.
@@ -1176,9 +1175,9 @@ class Context(object):
       memcache, or None.
     """
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(for_cas, bool):
-      raise TypeError('for_cas must be a bool; received %r' % for_cas)
+      raise TypeError('for_cas must be a bool; received {0!r}'.format(for_cas))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     options = (for_cas, namespace, deadline)
@@ -1197,9 +1196,9 @@ class Context(object):
   def memcache_set(self, key, value, time=0, namespace=None, use_cache=False,
                    deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
+      raise TypeError('time must be a number; received {0!r}'.format(time))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     options = ('set', time, namespace, deadline)
@@ -1211,9 +1210,9 @@ class Context(object):
 
   def memcache_add(self, key, value, time=0, namespace=None, deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
+      raise TypeError('time must be a number; received {0!r}'.format(time))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     return self._memcache_set_batcher.add((key, value),
@@ -1221,9 +1220,9 @@ class Context(object):
 
   def memcache_replace(self, key, value, time=0, namespace=None, deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
+      raise TypeError('time must be a number; received {0!r}'.format(time))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     options = ('replace', time, namespace, deadline)
@@ -1231,9 +1230,9 @@ class Context(object):
 
   def memcache_cas(self, key, value, time=0, namespace=None, deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
+      raise TypeError('time must be a number; received {0!r}'.format(time))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     return self._memcache_set_batcher.add((key, value),
@@ -1241,9 +1240,9 @@ class Context(object):
 
   def memcache_delete(self, key, seconds=0, namespace=None, deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(seconds, (int, long)):
-      raise TypeError('seconds must be a number; received %r' % seconds)
+      raise TypeError('seconds must be a number; received {0!r}'.format(seconds))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     return self._memcache_del_batcher.add(key, (seconds, namespace, deadline))
@@ -1251,12 +1250,12 @@ class Context(object):
   def memcache_incr(self, key, delta=1, initial_value=None, namespace=None,
                     deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(delta, (int, long)):
-      raise TypeError('delta must be a number; received %r' % delta)
+      raise TypeError('delta must be a number; received {0!r}'.format(delta))
     if initial_value is not None and not isinstance(initial_value, (int, long)):
-      raise TypeError('initial_value must be a number or None; received %r' %
-                      initial_value)
+      raise TypeError('initial_value must be a number or None; received {0!r}'.format(
+                      initial_value))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     return self._memcache_off_batcher.add((key, delta),
@@ -1265,12 +1264,12 @@ class Context(object):
   def memcache_decr(self, key, delta=1, initial_value=None, namespace=None,
                     deadline=None):
     if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
+      raise TypeError('key must be a string; received {0!r}'.format(key))
     if not isinstance(delta, (int, long)):
-      raise TypeError('delta must be a number; received %r' % delta)
+      raise TypeError('delta must be a number; received {0!r}'.format(delta))
     if initial_value is not None and not isinstance(initial_value, (int, long)):
-      raise TypeError('initial_value must be a number or None; received %r' %
-                      initial_value)
+      raise TypeError('initial_value must be a number or None; received {0!r}'.format(
+                      initial_value))
     if namespace is None:
       namespace = namespace_manager.get_namespace()
     return self._memcache_off_batcher.add((key, -delta),

--- a/ndb/context_test.py
+++ b/ndb/context_test.py
@@ -599,7 +599,7 @@ class ContextTestMixin(object):
   def testUrlFetch(self):
     self.testbed.init_urlfetch_stub()
     host, port = self.start_test_server()
-    fut = self.ctx.urlfetch('http://%s:%d' % (host, port))
+    fut = self.ctx.urlfetch('http://{0!s}:{1:d}'.format(host, port))
     result = fut.get_result()
     self.assertEqual(result.status_code, 200)
     self.assertTrue(isinstance(result.content, str))
@@ -881,7 +881,7 @@ class ContextMemcacheTestMixin(object):
     get_fut = self.ctx.get(key)
     ent = get_fut.get_result()
     self.assertTrue(ent is not None,
-                    'Memcache delete did block memcache set %r' % ent)
+                    'Memcache delete did block memcache set {0!r}'.format(ent))
 
   def testMemcacheAPI(self):
     self.ExpectErrors()
@@ -1068,7 +1068,7 @@ class ContextMemcacheTestMixin(object):
     ks = self.ctx._memcache_prefix + k.urlsafe()
     v = memcache.get(ks)
     self.assertTrue(isinstance(v, str),
-                    'Expected instanceof "str", got "%s"' % type(v))
+                    'Expected instanceof "str", got "{0!s}"'.format(type(v)))
 
   def testCorruptMemcache(self):
     # Check that corrupt memcache entries silently fail.

--- a/ndb/eventloop.py
+++ b/ndb/eventloop.py
@@ -234,8 +234,7 @@ class EventLoop(object):
         # Yes, wait_any() may return None even for a non-empty argument.
         # But no, it won't ever return an RPC not in its argument.
         if rpc not in self.rpcs:
-          raise RuntimeError('rpc %r was not given to wait_any as a choice %r' %
-                             (rpc, self.rpcs))
+          raise RuntimeError('rpc {0!r} was not given to wait_any as a choice {1!r}'.format(rpc, self.rpcs))
         callback, args, kwds = self.rpcs[rpc]
         del self.rpcs[rpc]
         if callback is not None:

--- a/ndb/key.py
+++ b/ndb/key.py
@@ -260,8 +260,8 @@ class Key(object):
               'Incomplete Key entry must be last')
       else:
         if not isinstance(id, (int, long, str)):
-          raise TypeError('Key id must be a string or a number; received %r' %
-                          id)
+          raise TypeError('Key id must be a string or a number; received {0!r}'.format(
+                          id))
       if isinstance(kind, type):
         kind = kind._get_kind()
       if isinstance(kind, unicode):
@@ -275,7 +275,7 @@ class Key(object):
     if parent is not None:
       if not isinstance(parent, Key):
         raise datastore_errors.BadValueError(
-            'Expected Key instance, got %r' % parent)
+            'Expected Key instance, got {0!r}'.format(parent))
       if not parent.id():
         raise datastore_errors.BadArgumentError(
             'Parent cannot have incomplete key')
@@ -332,8 +332,7 @@ class Key(object):
       tup = (kind, id_or_name)
       pairs.append(tup)
     if elem is None:
-      raise RuntimeError('Key reference has no path or elements (%r, %r, %r).'
-                         % (urlsafe, serialized, str(reference)))
+      raise RuntimeError('Key reference has no path or elements ({0!r}, {1!r}, {2!r}).'.format(urlsafe, serialized, str(reference)))
     # TODO: ensure that each element has a type and either an id or a name
     # You needn't specify app= or namespace= together with reference=,
     # serialized= or urlsafe=, but if you do, their values must match
@@ -365,15 +364,15 @@ class Key(object):
         args.append('None')
       elif isinstance(item, basestring):
         if not isinstance(item, str):
-          raise TypeError('Key item is not an 8-bit string %r' % item)
+          raise TypeError('Key item is not an 8-bit string {0!r}'.format(item))
         args.append(repr(item))
       else:
         args.append(str(item))
     if self.app() != _DefaultAppId():
-      args.append('app=%r' % self.app())
+      args.append('app={0!r}'.format(self.app()))
     if self.namespace() != _DefaultNamespace():
-      args.append('namespace=%r' % self.namespace())
-    return 'Key(%s)' % ', '.join(args)
+      args.append('namespace={0!r}'.format(self.namespace()))
+    return 'Key({0!s})'.format(', '.join(args))
 
   __str__ = __repr__
 
@@ -440,8 +439,8 @@ class Key(object):
   def __setstate__(self, state):
     """Private API used for pickling."""
     if len(state) != 1:
-      raise TypeError('Invalid state length, expected 1; received %i' %
-                      len(state))
+      raise TypeError('Invalid state length, expected 1; received {0:d}'.format(
+                      len(state)))
     kwargs = state[0]
     if not isinstance(kwargs, dict):
       raise TypeError('Key accepts a dict of keyword arguments as state; '
@@ -654,7 +653,7 @@ def _ConstructReference(cls, pairs=None, flat=None,
     if parent is not None:
       if not isinstance(parent, Key):
         raise datastore_errors.BadValueError(
-            'Expected Key instance, got %r' % parent)
+            'Expected Key instance, got {0!r}'.format(parent))
       pairs[:0] = parent.pairs()
       if app:
         if app != parent.app():
@@ -681,8 +680,7 @@ def _ConstructReference(cls, pairs=None, flat=None,
     if serialized:
       reference = _ReferenceFromSerialized(serialized)
     if not reference.path().element_size():
-      raise RuntimeError('Key reference has no path or elements (%r, %r, %r).'
-                         % (urlsafe, serialized, str(reference)))
+      raise RuntimeError('Key reference has no path or elements ({0!r}, {1!r}, {2!r}).'.format(urlsafe, serialized, str(reference)))
     # TODO: ensure that each element has a type and either an id or a name
     if not serialized:
       reference = _ReferenceFromReference(reference)
@@ -756,7 +754,7 @@ def _ReferenceFromPairs(pairs, reference=None, app=None, namespace=None):
     if t is int or t is long:
       # pylint: disable=superfluous-parens
       if not (1 <= idorname < _MAX_LONG):
-        raise ValueError('Key id number is too long; received %i' % idorname)
+        raise ValueError('Key id number is too long; received {0:d}'.format(idorname))
       elem.set_id(idorname)
     elif t is str:
       # pylint: disable=superfluous-parens
@@ -778,7 +776,7 @@ def _ReferenceFromPairs(pairs, reference=None, app=None, namespace=None):
     elif issubclass(t, (int, long)):
       # pylint: disable=superfluous-parens
       if not (1 <= idorname < _MAX_LONG):
-        raise ValueError('Key id number is too long; received %i' % idorname)
+        raise ValueError('Key id number is too long; received {0:d}'.format(idorname))
       elem.set_id(idorname)
     elif issubclass(t, basestring):
       if issubclass(t, unicode):
@@ -815,7 +813,7 @@ def _ReferenceFromReference(reference):
 def _ReferenceFromSerialized(serialized):
   """Construct a Reference from a serialized Reference."""
   if not isinstance(serialized, basestring):
-    raise TypeError('serialized must be a string; received %r' % serialized)
+    raise TypeError('serialized must be a string; received {0!r}'.format(serialized))
   elif isinstance(serialized, unicode):
     serialized = serialized.encode('utf8')
   return entity_pb.Reference(serialized)
@@ -827,7 +825,7 @@ def _DecodeUrlSafe(urlsafe):
   This returns the decoded string.
   """
   if not isinstance(urlsafe, basestring):
-    raise TypeError('urlsafe must be a string; received %r' % urlsafe)
+    raise TypeError('urlsafe must be a string; received {0!r}'.format(urlsafe))
   if isinstance(urlsafe, unicode):
     urlsafe = urlsafe.encode('utf8')
   mod = len(urlsafe) % 4

--- a/ndb/model.py
+++ b/ndb/model.py
@@ -526,7 +526,7 @@ class IndexProperty(_NotEqualMixin):
 
   def __repr__(self):
     """Return a string representation."""
-    return '%s(name=%r, direction=%r)' % (self.__class__.__name__,
+    return '{0!s}(name={1!r}, direction={2!r})'.format(self.__class__.__name__,
                                           self.name,
                                           self.direction)
 
@@ -570,10 +570,10 @@ class Index(_NotEqualMixin):
   def __repr__(self):
     """Return a string representation."""
     parts = []
-    parts.append('kind=%r' % self.kind)
-    parts.append('properties=%r' % self.properties)
-    parts.append('ancestor=%s' % self.ancestor)
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(parts))
+    parts.append('kind={0!r}'.format(self.kind))
+    parts.append('properties={0!r}'.format(self.properties))
+    parts.append('ancestor={0!s}'.format(self.ancestor))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(parts))
 
   def __eq__(self, other):
     """Compare two indexes."""
@@ -620,10 +620,10 @@ class IndexState(_NotEqualMixin):
   def __repr__(self):
     """Return a string representation."""
     parts = []
-    parts.append('definition=%r' % self.definition)
-    parts.append('state=%r' % self.state)
-    parts.append('id=%d' % self.id)
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(parts))
+    parts.append('definition={0!r}'.format(self.definition))
+    parts.append('state={0!r}'.format(self.state))
+    parts.append('id={0:d}'.format(self.id))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(parts))
 
   def __eq__(self, other):
     """Compare two index states."""
@@ -752,7 +752,7 @@ class _BaseValue(_NotEqualMixin):
     self.b_val = b_val
 
   def __repr__(self):
-    return '_BaseValue(%r)' % (self.b_val,)
+    return '_BaseValue({0!r})'.format(self.b_val)
 
   def __eq__(self, other):
     if not isinstance(other, _BaseValue):
@@ -901,9 +901,9 @@ class Property(ModelAttribute):
       if isinstance(name, unicode):
         name = name.encode('utf-8')
       if not isinstance(name, str):
-        raise TypeError('Name %r is not a string' % (name,))
+        raise TypeError('Name {0!r} is not a string'.format(name))
       if '.' in name:
-        raise ValueError('Name %r cannot contain period characters' % (name,))
+        raise ValueError('Name {0!r} cannot contain period characters'.format(name))
       self._name = name
     if indexed is not None:
       self._indexed = indexed
@@ -922,8 +922,8 @@ class Property(ModelAttribute):
       raise ValueError('repeated is incompatible with required or default')
     if choices is not None:
       if not isinstance(choices, (list, tuple, set, frozenset)):
-        raise TypeError('choices must be a list, tuple or set; received %r' %
-                        choices)
+        raise TypeError('choices must be a list, tuple or set; received {0!r}'.format(
+                        choices))
       # TODO: Call _validate() on each choice?
       self._choices = frozenset(choices)
     if validator is not None:
@@ -935,8 +935,8 @@ class Property(ModelAttribute):
       # value.lower() or value.strip() is fine, but one that returns
       # value + '$' is not.
       if not hasattr(validator, '__call__'):
-        raise TypeError('validator must be callable or None; received %r' %
-                        validator)
+        raise TypeError('validator must be callable or None; received {0!r}'.format(
+                        validator))
       self._validator = validator
     # Keep a unique creation counter.
     Property.__creation_counter_global += 1
@@ -956,9 +956,9 @@ class Property(ModelAttribute):
         if i >= cls._positional:
           if attr.startswith('_'):
             attr = attr[1:]
-          s = '%s=%s' % (attr, s)
+          s = '{0!s}={1!s}'.format(attr, s)
         args.append(s)
-    s = '%s(%s)' % (self.__class__.__name__, ', '.join(args))
+    s = '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(args))
     return s
 
   def _datastore_type(self, value):
@@ -981,7 +981,7 @@ class Property(ModelAttribute):
     # NOTE: This is also used by query.gql().
     if not self._indexed:
       raise datastore_errors.BadFilterError(
-          'Cannot query for unindexed property %s' % self._name)
+          'Cannot query for unindexed property {0!s}'.format(self._name))
     from .query import FilterNode  # Import late to avoid circular imports.
     if value is not None:
       value = self._do_validate(value)
@@ -1033,11 +1033,11 @@ class Property(ModelAttribute):
     """
     if not self._indexed:
       raise datastore_errors.BadFilterError(
-          'Cannot query for unindexed property %s' % self._name)
+          'Cannot query for unindexed property {0!s}'.format(self._name))
     from .query import FilterNode  # Import late to avoid circular imports.
     if not isinstance(value, (list, tuple, set, frozenset)):
       raise datastore_errors.BadArgumentError(
-          'Expected list, tuple or set, got %r' % (value,))
+          'Expected list, tuple or set, got {0!r}'.format(value))
     values = []
     for val in value:
       if val is not None:
@@ -1097,8 +1097,7 @@ class Property(ModelAttribute):
     if self._choices is not None:
       if value not in self._choices:
         raise datastore_errors.BadValueError(
-            'Value %r for property %s is not an allowed choice' %
-            (value, self._name))
+            'Value {0!r} for property {1!s} is not an allowed choice'.format(value, self._name))
     return value
 
   def _fix_up(self, cls, code_name):
@@ -1137,8 +1136,7 @@ class Property(ModelAttribute):
           'You cannot set property values of a projection entity')
     if self._repeated:
       if not isinstance(value, (list, tuple, set, frozenset)):
-        raise datastore_errors.BadValueError('Expected list or tuple, got %r' %
-                                             (value,))
+        raise datastore_errors.BadValueError('Expected list or tuple, got {0!r}'.format(value))
       value = [self._do_validate(v) for v in value]
     else:
       if value is not None:
@@ -1367,7 +1365,7 @@ class Property(ModelAttribute):
     if entity._projection:
       if self._name not in entity._projection:
         raise UnprojectedPropertyError(
-            'Property %s is not in the projection' % (self._name,))
+            'Property {0!s} is not in the projection'.format(self._name))
     return self._get_user_value(entity)
 
   def _delete_value(self, entity):
@@ -1512,7 +1510,7 @@ class Property(ModelAttribute):
       overrides this method to handle subproperties.)
     """
     if require_indexed and not self._indexed:
-      raise InvalidPropertyError('Property is unindexed %s' % self._name)
+      raise InvalidPropertyError('Property is unindexed {0!s}'.format(self._name))
     if rest:
       raise InvalidPropertyError('Referencing subproperty %s.%s '
                                  'but %s is not a structured property' %
@@ -1541,11 +1539,10 @@ class Property(ModelAttribute):
 def _validate_key(value, entity=None):
   if not isinstance(value, Key):
     # TODO: BadKeyError.
-    raise datastore_errors.BadValueError('Expected Key, got %r' % value)
+    raise datastore_errors.BadValueError('Expected Key, got {0!r}'.format(value))
   if entity and entity.__class__ not in (Model, Expando):
     if value.kind() != entity._get_kind():
-      raise KindError('Expected Key kind to be %s; received %s' %
-                      (entity._get_kind(), value.kind()))
+      raise KindError('Expected Key kind to be {0!s}; received {1!s}'.format(entity._get_kind(), value.kind()))
   return value
 
 
@@ -1592,8 +1589,7 @@ class BooleanProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, bool):
-      raise datastore_errors.BadValueError('Expected bool, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected bool, got {0!r}'.format(value))
     return value
 
   def _db_set_value(self, v, unused_p, value):
@@ -1615,8 +1611,7 @@ class IntegerProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, (int, long)):
-      raise datastore_errors.BadValueError('Expected integer, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected integer, got {0!r}'.format(value))
     return int(value)
 
   def _db_set_value(self, v, unused_p, value):
@@ -1639,8 +1634,7 @@ class FloatProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, (int, long, float)):
-      raise datastore_errors.BadValueError('Expected float, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected float, got {0!r}'.format(value))
     return float(value)
 
   def _db_set_value(self, v, unused_p, value):
@@ -1670,7 +1664,7 @@ class _CompressedValue(_NotEqualMixin):
     self.z_val = z_val
 
   def __repr__(self):
-    return '_CompressedValue(%s)' % repr(self.z_val)
+    return '_CompressedValue({0!s})'.format(repr(self.z_val))
 
   def __eq__(self, other):
     if not isinstance(other, _CompressedValue):
@@ -1710,14 +1704,12 @@ class BlobProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, str):
-      raise datastore_errors.BadValueError('Expected str, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected str, got {0!r}'.format(value))
     if (self._indexed and
         not isinstance(self, TextProperty) and
         len(value) > _MAX_STRING_LENGTH):
       raise datastore_errors.BadValueError(
-          'Indexed value %s must be at most %d bytes' %
-          (self._name, _MAX_STRING_LENGTH))
+          'Indexed value {0!s} must be at most {1:d} bytes'.format(self._name, _MAX_STRING_LENGTH))
 
   def _to_base_type(self, value):
     if self._compressed:
@@ -1772,17 +1764,14 @@ class TextProperty(BlobProperty):
         length = len(value)
         value = value.decode('utf-8')
       except UnicodeError:
-        raise datastore_errors.BadValueError('Expected valid UTF-8, got %r' %
-                                             (value,))
+        raise datastore_errors.BadValueError('Expected valid UTF-8, got {0!r}'.format(value))
     elif isinstance(value, unicode):
       length = len(value.encode('utf-8'))
     else:
-      raise datastore_errors.BadValueError('Expected string, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected string, got {0!r}'.format(value))
     if self._indexed and length > _MAX_STRING_LENGTH:
       raise datastore_errors.BadValueError(
-          'Indexed value %s must be at most %d bytes' %
-          (self._name, _MAX_STRING_LENGTH))
+          'Indexed value {0!s} must be at most {1:d} bytes'.format(self._name, _MAX_STRING_LENGTH))
 
   def _to_base_type(self, value):
     if isinstance(value, unicode):
@@ -1816,8 +1805,7 @@ class GeoPtProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, GeoPt):
-      raise datastore_errors.BadValueError('Expected GeoPt, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected GeoPt, got {0!r}'.format(value))
 
   def _db_set_value(self, v, p, value):
     if not isinstance(value, GeoPt):
@@ -1877,7 +1865,7 @@ class JsonProperty(BlobProperty):
 
   def _validate(self, value):
     if self._json_type is not None and not isinstance(value, self._json_type):
-      raise TypeError('JSON property must be a %s' % self._json_type)
+      raise TypeError('JSON property must be a {0!s}'.format(self._json_type))
 
   # Use late import so the dependency is optional.
 
@@ -1928,8 +1916,7 @@ class UserProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, users.User):
-      raise datastore_errors.BadValueError('Expected User, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected User, got {0!r}'.format(value))
 
   def _prepare_for_put(self, entity):
     if (self._auto_current_user or
@@ -1981,7 +1968,7 @@ class KeyProperty(Property):
           raise TypeError('You can only specify one kind')
         kind = arg
       elif arg is not None:
-        raise TypeError('Unexpected positional argument: %r' % (arg,))
+        raise TypeError('Unexpected positional argument: {0!r}'.format(arg))
 
     if name is None:
       name = kwds.pop('name', None)
@@ -2010,15 +1997,14 @@ class KeyProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, Key):
-      raise datastore_errors.BadValueError('Expected Key, got %r' % (value,))
+      raise datastore_errors.BadValueError('Expected Key, got {0!r}'.format(value))
     # Reject incomplete keys.
     if not value.id():
-      raise datastore_errors.BadValueError('Expected complete Key, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected complete Key, got {0!r}'.format(value))
     if self._kind is not None:
       if value.kind() != self._kind:
         raise datastore_errors.BadValueError(
-            'Expected Key with kind=%r, got %r' % (self._kind, value))
+            'Expected Key with kind={0!r}, got {1!r}'.format(self._kind, value))
 
   def _db_set_value(self, v, unused_p, value):
     if not isinstance(value, Key):
@@ -2053,8 +2039,7 @@ class BlobKeyProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, datastore_types.BlobKey):
-      raise datastore_errors.BadValueError('Expected BlobKey, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected BlobKey, got {0!r}'.format(value))
 
   def _db_set_value(self, v, p, value):
     if not isinstance(value, datastore_types.BlobKey):
@@ -2107,8 +2092,7 @@ class DateTimeProperty(Property):
 
   def _validate(self, value):
     if not isinstance(value, datetime.datetime):
-      raise datastore_errors.BadValueError('Expected datetime, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected datetime, got {0!r}'.format(value))
 
   def _now(self):
     return datetime.datetime.utcnow()
@@ -2176,8 +2160,7 @@ class DateProperty(DateTimeProperty):
 
   def _validate(self, value):
     if not isinstance(value, datetime.date):
-      raise datastore_errors.BadValueError('Expected date, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected date, got {0!r}'.format(value))
 
   def _to_base_type(self, value):
     assert isinstance(value, datetime.date), repr(value)
@@ -2196,8 +2179,7 @@ class TimeProperty(DateTimeProperty):
 
   def _validate(self, value):
     if not isinstance(value, datetime.time):
-      raise datastore_errors.BadValueError('Expected time, got %r' %
-                                           (value,))
+      raise datastore_errors.BadValueError('Expected time, got {0!r}'.format(value))
 
   def _to_base_type(self, value):
     assert isinstance(value, datetime.time), repr(value)
@@ -2281,8 +2263,7 @@ class StructuredProperty(_StructuredGetForDictMixin):
         # This is executed when we never execute the above break.
         prop = None
     if prop is None:
-      raise AttributeError('Model subclass %s has no attribute %s' %
-                           (self._modelclass.__name__, attrname))
+      raise AttributeError('Model subclass {0!s} has no attribute {1!s}'.format(self._modelclass.__name__, attrname))
     prop_copy = copy.copy(prop)
     prop_copy._name = self._name + '.' + prop_copy._name
     # Cache the outcome, so subsequent requests for the same attribute
@@ -2297,7 +2278,7 @@ class StructuredProperty(_StructuredGetForDictMixin):
           'StructuredProperty filter can only use ==')
     if not self._indexed:
       raise datastore_errors.BadFilterError(
-          'Cannot query for unindexed StructuredProperty %s' % self._name)
+          'Cannot query for unindexed StructuredProperty {0!s}'.format(self._name))
     # Import late to avoid circular imports.
     from .query import ConjunctionNode, PostFilterNode
     from .query import RepeatedStructuredPropertyPredicate
@@ -2314,7 +2295,7 @@ class StructuredProperty(_StructuredGetForDictMixin):
       if prop._repeated:
         if vals:
           raise datastore_errors.BadFilterError(
-              'Cannot query for non-empty repeated property %s' % prop._name)
+              'Cannot query for non-empty repeated property {0!s}'.format(prop._name))
         continue
       assert isinstance(vals, list) and len(vals) == 1, repr(vals)
       val = vals[0]
@@ -2338,7 +2319,7 @@ class StructuredProperty(_StructuredGetForDictMixin):
   def _IN(self, value):
     if not isinstance(value, (list, tuple, set, frozenset)):
       raise datastore_errors.BadArgumentError(
-          'Expected list, tuple or set, got %r' % (value,))
+          'Expected list, tuple or set, got {0!r}'.format(value))
     from .query import DisjunctionNode, FalseNode
     # Expand to a series of == filters.
     filters = [self._comparison('=', val) for val in value]
@@ -2356,8 +2337,7 @@ class StructuredProperty(_StructuredGetForDictMixin):
       # A dict is assumed to be the result of a _to_dict() call.
       return self._modelclass(**value)
     if not isinstance(value, self._modelclass):
-      raise datastore_errors.BadValueError('Expected %s instance, got %r' %
-                                           (self._modelclass.__name__, value))
+      raise datastore_errors.BadValueError('Expected {0!s} instance, got {1!r}'.format(self._modelclass.__name__, value))
 
   def _has_value(self, entity, rest=None):
     # rest: optional list of attribute names to check in addition.
@@ -2514,7 +2494,7 @@ class StructuredProperty(_StructuredGetForDictMixin):
     """
     if not rest:
       raise InvalidPropertyError(
-          'Structured property %s requires a subproperty' % self._name)
+          'Structured property {0!s} requires a subproperty'.format(self._name))
     self._modelclass._check_properties([rest], require_indexed=require_indexed)
 
   def _get_base_value_at_index(self, entity, index):
@@ -2556,8 +2536,8 @@ class LocalStructuredProperty(_StructuredGetForDictMixin, BlobProperty):
                                                   compressed=compressed,
                                                   **kwds)
     if self._indexed:
-      raise NotImplementedError('Cannot index LocalStructuredProperty %s.' %
-                                self._name)
+      raise NotImplementedError('Cannot index LocalStructuredProperty {0!s}.'.format(
+                                self._name))
     self._modelclass = modelclass
     self._keep_keys = keep_keys
 
@@ -2566,8 +2546,7 @@ class LocalStructuredProperty(_StructuredGetForDictMixin, BlobProperty):
       # A dict is assumed to be the result of a _to_dict() call.
       return self._modelclass(**value)
     if not isinstance(value, self._modelclass):
-      raise datastore_errors.BadValueError('Expected %s instance, got %r' %
-                                           (self._modelclass.__name__, value))
+      raise datastore_errors.BadValueError('Expected {0!s} instance, got {1!r}'.format(self._modelclass.__name__, value))
 
   def _to_base_type(self, value):
     if isinstance(value, self._modelclass):
@@ -2641,8 +2620,7 @@ class GenericProperty(Property):
         value = value.encode('utf-8')
       if isinstance(value, basestring) and len(value) > _MAX_STRING_LENGTH:
         raise datastore_errors.BadValueError(
-            'Indexed value %s must be at most %d bytes' %
-            (self._name, _MAX_STRING_LENGTH))
+            'Indexed value {0!s} must be at most {1:d} bytes'.format(self._name, _MAX_STRING_LENGTH))
 
   def _db_get_value(self, v, p):
     # This is awkward but there seems to be no faster way to inspect
@@ -2763,8 +2741,7 @@ class GenericProperty(Property):
       p.set_meaning_uri(_MEANING_URI_COMPRESSED)
       p.set_meaning(entity_pb.Property.BLOB)
     else:
-      raise NotImplementedError('Property %s does not support %s types.' %
-                                (self._name, type(value)))
+      raise NotImplementedError('Property {0!s} does not support {1!s} types.'.format(self._name, type(value)))
 
 
 class ComputedProperty(GenericProperty):
@@ -2851,8 +2828,8 @@ class MetaModel(type):
   def __repr__(cls):
     props = []
     for _, prop in sorted(cls._properties.iteritems()):
-      props.append('%s=%r' % (prop._code_name, prop))
-    return '%s<%s>' % (cls.__name__, ', '.join(props))
+      props.append('{0!s}={1!r}'.format(prop._code_name, prop))
+    return '{0!s}<{1!s}>'.format(cls.__name__, ', '.join(props))
 
 
 class Model(_NotEqualMixin):
@@ -2989,7 +2966,7 @@ class Model(_NotEqualMixin):
     for name, value in kwds.iteritems():
       prop = getattr(cls, name)  # Raises AttributeError for unknown properties.
       if not isinstance(prop, Property):
-        raise TypeError('Cannot set non-property %s' % name)
+        raise TypeError('Cannot set non-property {0!s}'.format(name))
       prop._set_value(self, value)
 
   def _find_uninitialized(self):
@@ -3011,7 +2988,7 @@ class Model(_NotEqualMixin):
     baddies = self._find_uninitialized()
     if baddies:
       raise datastore_errors.BadValueError(
-          'Entity has uninitialized properties: %s' % ', '.join(baddies))
+          'Entity has uninitialized properties: {0!s}'.format(', '.join(baddies)))
 
   def __repr__(self):
     """Return an unambiguous string representation of an entity."""
@@ -3031,13 +3008,13 @@ class Model(_NotEqualMixin):
             rep = '[]'
         else:
           rep = prop._value_to_repr(val)
-        args.append('%s=%s' % (prop._code_name, rep))
+        args.append('{0!s}={1!s}'.format(prop._code_name, rep))
     args.sort()
     if self._key is not None:
-      args.insert(0, 'key=%r' % self._key)
+      args.insert(0, 'key={0!r}'.format(self._key))
     if self._projection:
-      args.append('_projection=%r' % (self._projection,))
-    s = '%s(%s)' % (self.__class__.__name__, ', '.join(args))
+      args.append('_projection={0!r}'.format(self._projection))
+    s = '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(args))
     return s
 
   @classmethod
@@ -3097,8 +3074,8 @@ class Model(_NotEqualMixin):
     modelclass = cls._kind_map.get(kind, default_model)
     if modelclass is None:
       raise KindError(
-          "No model class found for kind '%s'. Did you forget to import it?" %
-          kind)
+          "No model class found for kind '{0!s}'. Did you forget to import it?".format(
+          kind))
     return modelclass
 
   def _has_complete_key(self):
@@ -3189,7 +3166,7 @@ class Model(_NotEqualMixin):
   def _from_pb(cls, pb, set_key=True, ent=None, key=None):
     """Internal helper to create an entity from an EntityProto protobuf."""
     if not isinstance(pb, entity_pb.EntityProto):
-      raise TypeError('pb must be a EntityProto; received %r' % pb)
+      raise TypeError('pb must be a EntityProto; received {0!r}'.format(pb))
     if ent is None:
       ent = cls()
 
@@ -3383,7 +3360,7 @@ class Model(_NotEqualMixin):
     Raises:
       InvalidPropertyError.
     """
-    raise InvalidPropertyError('Unknown property %s' % name)
+    raise InvalidPropertyError('Unknown property {0!s}'.format(name))
 
   def _validate_key(self, key):
     """Validation for _key attribute (designed to be overridden).
@@ -3435,7 +3412,7 @@ class Model(_NotEqualMixin):
   def _gql(cls, query_string, *args, **kwds):
     """Run a GQL query."""
     from .query import gql  # Import late to avoid circular imports.
-    return gql('SELECT * FROM %s %s' % (cls._class_name(), query_string),
+    return gql('SELECT * FROM {0!s} {1!s}'.format(cls._class_name(), query_string),
                *args, **kwds)
   gql = _gql
 
@@ -3514,7 +3491,7 @@ class Model(_NotEqualMixin):
     # (End of super-special argument parsing.)
     # TODO: Test the heck out of this, in all sorts of evil scenarios.
     if not isinstance(name, basestring):
-      raise TypeError('name must be a string; received %r' % name)
+      raise TypeError('name must be a string; received {0!r}'.format(name))
     elif not name:
       raise ValueError('name cannot be an empty string.')
     key = Key(cls, name, app=app, namespace=namespace, parent=parent)
@@ -3740,8 +3717,8 @@ class Expando(Model):
       return super(Expando, self).__delattr__(name)
     prop = self._properties.get(name)
     if not isinstance(prop, Property):
-      raise TypeError('Model properties must be Property instances; not %r' %
-                      prop)
+      raise TypeError('Model properties must be Property instances; not {0!r}'.format(
+                      prop))
     prop._delete_value(self)
     if prop in self.__class__._properties:
       raise RuntimeError('Property %s still in the list of properties for the '
@@ -3878,7 +3855,7 @@ def non_transactional(func, args, kwds, allow_existing=True):
     return func(*args, **kwds)
   if not allow_existing:
     raise datastore_errors.BadRequestError(
-        '%s cannot be called within a transaction.' % func.__name__)
+        '{0!s} cannot be called within a transaction.'.format(func.__name__))
   save_ctx = ctx
   while ctx.in_transaction():
     ctx = ctx._parent_context

--- a/ndb/model_test.py
+++ b/ndb/model_test.py
@@ -468,7 +468,7 @@ class ModelTests(test_utils.NDBTest):
   def assertBetween(self, x, a, b):
     '''Asserts a <= x <= b.'''
     if not a <= x <= b:
-      self.fail('%s is not between %s and %s' % (x, a, b))
+      self.fail('{0!s} is not between {1!s} and {2!s}'.format(x, a, b))
 
   def tearDown(self):
     self.assertTrue(model.Model._properties == {})
@@ -1250,8 +1250,8 @@ class ModelTests(test_utils.NDBTest):
     def my_validator(prop, value):
       value = value.lower()
       if not value.startswith('a'):
-        raise datastore_errors.BadValueError('%s does not start with "a"' %
-                                             prop._name)
+        raise datastore_errors.BadValueError('{0!s} does not start with "a"'.format(
+                                             prop._name))
       return value
 
     class MyModel(model.Model):
@@ -2370,11 +2370,10 @@ property <
     self.assertEqual(repr(small), "Biggy(blob='xyz', text=u'abc')")
     large = Biggy(blob='x' * 1500, text='a' * 1500)
     self.assertEqual(repr(large),
-                     "Biggy(blob='%s', text='%s')" % ('x' * 1500, 'a' * 1500))
+                     "Biggy(blob='{0!s}', text='{1!s}')".format('x' * 1500, 'a' * 1500))
     huge = Biggy(blob='x' * 2000, text='a' * 2000)
     self.assertEqual(repr(huge),
-                     "Biggy(blob='%s...', text='%s...')" %
-                     ('x' * 1499, 'a' * 1499))
+                     "Biggy(blob='{0!s}...', text='{1!s}...')".format('x' * 1499, 'a' * 1499))
 
   def testModelRepr_CustomRepr(self):
     # Demonstrate how to override a property's repr.
@@ -3119,11 +3118,11 @@ property <
       (test_config, db_model) = model_config(write_empty_list)
 
       for input_, output in protobuf_to_model:
-        desc = 'proto(%s) -> %s model(%s) test ' % (input_, test_config, output)
+        desc = 'proto({0!s}) -> {1!s} model({2!s}) test '.format(input_, test_config, output)
         self.RunOneEmptyListTest(True, input_, output, desc, db_model)
 
       for input_, output in model_to_protobuf:
-        desc = '%s model(%s) -> proto(%s) test ' % (input_, test_config, output)
+        desc = '{0!s} model({1!s}) -> proto({2!s}) test '.format(input_, test_config, output)
         self.RunOneEmptyListTest(False, input_, output, desc, db_model)
     finally:
       model.Property._write_empty_list = property_before
@@ -4748,9 +4747,9 @@ property <
     self.assertEqual(
         repr(y),
         'M(key=Key(\'M\', 1), ' +
-        'b=%r, ' % ('b' * 100) +
-        'l=%r, ' % Foo(name=u'joe') +
-        't=%r)' % (u't' * 100))
+        'b={0!r}, '.format(('b' * 100)) +
+        'l={0!r}, '.format(Foo(name=u'joe')) +
+        't={0!r})'.format((u't' * 100)))
 
   def testCorruption(self):
     # Thanks to Ricardo Banffy
@@ -5226,7 +5225,7 @@ class CacheTests(test_utils.NDBTest):
         return eq
 
       def __repr__(self):
-        return 'FuzzyDate(%r, %r)' % (self.first, self.last)
+        return 'FuzzyDate({0!r}, {1!r})'.format(self.first, self.last)
 
     class FuzzyDateModel(model.Model):
       first = model.DateProperty()

--- a/ndb/msgprop.py
+++ b/ndb/msgprop.py
@@ -186,8 +186,7 @@ class EnumProperty(model.IntegerProperty):
       TypeError if the value is not an instance of self._enum_type.
     """
     if not isinstance(value, self._enum_type):
-      raise TypeError('Expected a %s instance, got %r instead' %
-                      (self._enum_type.__name__, value))
+      raise TypeError('Expected a {0!s} instance, got {1!r} instead'.format(self._enum_type.__name__, value))
 
   def _to_base_type(self, enum):
     """Convert an Enum value to a base type (integer) value."""
@@ -228,18 +227,17 @@ def _analyze_indexed_fields(indexed_fields):
   result = {}
   for field_name in indexed_fields:
     if not isinstance(field_name, basestring):
-      raise TypeError('Field names must be strings; got %r' % (field_name,))
+      raise TypeError('Field names must be strings; got {0!r}'.format(field_name))
     if '.' not in field_name:
       if field_name in result:
-        raise ValueError('Duplicate field name %s' % field_name)
+        raise ValueError('Duplicate field name {0!s}'.format(field_name))
       result[field_name] = None
     else:
       head, tail = field_name.split('.', 1)
       if head not in result:
         result[head] = [tail]
       elif result[head] is None:
-        raise ValueError('Field name %s conflicts with ancestor %s' %
-                         (field_name, head))
+        raise ValueError('Field name {0!s} conflicts with ancestor {1!s}'.format(field_name, head))
       else:
         result[head].append(tail)
   return result
@@ -269,23 +267,22 @@ def _make_model_class(message_type, indexed_fields, **props):
   analyzed = _analyze_indexed_fields(indexed_fields)
   for field_name, sub_fields in analyzed.iteritems():
     if field_name in props:
-      raise ValueError('field name %s is reserved' % field_name)
+      raise ValueError('field name {0!s} is reserved'.format(field_name))
     try:
       field = message_type.field_by_name(field_name)
     except KeyError:
-      raise ValueError('Message type %s has no field named %s' %
-                       (message_type.__name__, field_name))
+      raise ValueError('Message type {0!s} has no field named {1!s}'.format(message_type.__name__, field_name))
     if isinstance(field, messages.MessageField):
       if not sub_fields:
         raise ValueError(
-            'MessageField %s cannot be indexed, only sub-fields' % field_name)
+            'MessageField {0!s} cannot be indexed, only sub-fields'.format(field_name))
       sub_model_class = _make_model_class(field.type, sub_fields)
       prop = model.StructuredProperty(sub_model_class, field_name,
                                       repeated=field.repeated)
     else:
       if sub_fields is not None:
         raise ValueError(
-            'Unstructured field %s cannot have indexed sub-fields' % field_name)
+            'Unstructured field {0!s} cannot have indexed sub-fields'.format(field_name))
       if isinstance(field, messages.EnumField):
         prop = EnumProperty(field.type, field_name, repeated=field.repeated)
       elif isinstance(field, messages.BytesField):
@@ -295,7 +292,7 @@ def _make_model_class(message_type, indexed_fields, **props):
         # IntegerField, FloatField, BooleanField, StringField.
         prop = model.GenericProperty(field_name, repeated=field.repeated)
     props[field_name] = prop
-  return model.MetaModel('_%s__Model' % message_type.__name__,
+  return model.MetaModel('_{0!s}__Model'.format(message_type.__name__),
                          (model.Model,), props)
 
 
@@ -344,7 +341,7 @@ class MessageProperty(model.StructuredProperty):
       protocol = _default_protocol
     self._protocol = protocol
     self._protocol_impl = _protocols_registry.lookup_by_name(protocol)
-    blob_prop = model.BlobProperty('__%s__' % self._protocol)
+    blob_prop = model.BlobProperty('__{0!s}__'.format(self._protocol))
     # TODO: Solve this without reserving 'blob_'.
     message_class = _make_model_class(message_type, self._indexed_fields,
                                       blob_=blob_prop)
@@ -380,7 +377,7 @@ class MessageProperty(model.StructuredProperty):
       # Perhaps it was written using a different protocol.
       protocol = None
       for name in _protocols_registry.names:
-        key = '__%s__' % name
+        key = '__{0!s}__'.format(name)
         if key in ent._values:
           blob = ent._values[key]
           if isinstance(blob, model._BaseValue):

--- a/ndb/polymodel.py
+++ b/ndb/polymodel.py
@@ -67,7 +67,7 @@ class _ClassKeyProperty(model.StringProperty):
 
   def _set_value(self, entity, value):
     """The class_ property is read-only from the user's perspective."""
-    raise TypeError('%s is a read-only property' % self._code_name)
+    raise TypeError('{0!s} is a read-only property'.format(self._code_name))
 
   def _get_value(self, entity):
     """Compute and store a default value if necessary."""

--- a/ndb/query.py
+++ b/ndb/query.py
@@ -195,8 +195,7 @@ class RepeatedStructuredPropertyPredicate(datastore_query.FilterPredicate):
     stripped_keys = []
     for key in match_keys:
       if not key.startswith(key_prefix):
-        raise ValueError('key %r does not begin with the specified prefix of %s'
-                         % (key, key_prefix))
+        raise ValueError('key {0!r} does not begin with the specified prefix of {1!s}'.format(key, key_prefix))
       stripped_keys.append(key[len(key_prefix):])
     value_map = datastore_query._make_key_value_map(pb, stripped_keys)
     self.match_values = tuple(value_map[key][0] for key in stripped_keys)
@@ -291,12 +290,11 @@ class Parameter(ParameterizedThing):
       key: The Parameter key, must be either an integer or a string.
     """
     if not isinstance(key, (int, long, basestring)):
-      raise TypeError('Parameter key must be an integer or string, not %s' %
-                      (key,))
+      raise TypeError('Parameter key must be an integer or string, not {0!s}'.format(key))
     self.__key = key
 
   def __repr__(self):
-    return '%s(%r)' % (self.__class__.__name__, self.__key)
+    return '{0!s}({1!r})'.format(self.__class__.__name__, self.__key)
 
   def __eq__(self, other):
     if not isinstance(other, Parameter):
@@ -312,7 +310,7 @@ class Parameter(ParameterizedThing):
     key = self.__key
     if key not in bindings:
       raise datastore_errors.BadArgumentError(
-          'Parameter :%s is not bound.' % key)
+          'Parameter :{0!s} is not bound.'.format(key))
     value = bindings[key]
     used[key] = True
     return value
@@ -336,7 +334,7 @@ class ParameterizedFunction(ParameterizedThing):
     self.__method = getattr(gqli, '_GQL' + gql_method.__name__)
 
   def __repr__(self):
-    return 'ParameterizedFunction(%r, %r)' % (self.__func, self.__values)
+    return 'ParameterizedFunction({0!r}, {1!r})'.format(self.__func, self.__values)
 
   def __eq__(self, other):
     if not isinstance(other, ParameterizedFunction):
@@ -446,11 +444,11 @@ class ParameterNode(Node):
 
   def __new__(cls, prop, op, param):
     if not isinstance(prop, model.Property):
-      raise TypeError('Expected a Property, got %r' % (prop,))
+      raise TypeError('Expected a Property, got {0!r}'.format(prop))
     if op not in _OPS:
-      raise TypeError('Expected a valid operator, got %r' % (op,))
+      raise TypeError('Expected a valid operator, got {0!r}'.format(op))
     if not isinstance(param, ParameterizedThing):
-      raise TypeError('Expected a ParameterizedThing, got %r' % (param,))
+      raise TypeError('Expected a ParameterizedThing, got {0!r}'.format(param))
     obj = super(ParameterNode, cls).__new__(cls)
     obj.__prop = prop
     obj.__op = op
@@ -458,7 +456,7 @@ class ParameterNode(Node):
     return obj
 
   def __repr__(self):
-    return 'ParameterNode(%r, %r, %r)' % (self.__prop, self.__op, self.__param)
+    return 'ParameterNode({0!r}, {1!r}, {2!r})'.format(self.__prop, self.__op, self.__param)
 
   def __eq__(self, other):
     if not isinstance(other, ParameterNode):
@@ -469,7 +467,7 @@ class ParameterNode(Node):
 
   def _to_filter(self, post=False):
     raise datastore_errors.BadArgumentError(
-        'Parameter :%s is not bound.' % (self.__param.key,))
+        'Parameter :{0!s} is not bound.'.format(self.__param.key))
 
   def resolve(self, bindings, used):
     value = self.__param.resolve(bindings, used)
@@ -506,7 +504,7 @@ class FilterNode(Node):
     return self
 
   def __repr__(self):
-    return '%s(%r, %r, %r)' % (self.__class__.__name__,
+    return '{0!s}({1!r}, {2!r}, {3!r})'.format(self.__class__.__name__,
                                self.__name, self.__opsymbol, self.__value)
 
   def __eq__(self, other):
@@ -544,7 +542,7 @@ class PostFilterNode(Node):
     return self
 
   def __repr__(self):
-    return '%s(%s)' % (self.__class__.__name__, self.predicate)
+    return '{0!s}({1!s})'.format(self.__class__.__name__, self.predicate)
 
   def __eq__(self, other):
     if not isinstance(other, PostFilterNode):
@@ -602,7 +600,7 @@ class ConjunctionNode(Node):
     return iter(self.__nodes)
 
   def __repr__(self):
-    return 'AND(%s)' % (', '.join(map(str, self.__nodes)))
+    return 'AND({0!s})'.format((', '.join(map(str, self.__nodes))))
 
   def __eq__(self, other):
     if not isinstance(other, ConjunctionNode):
@@ -663,7 +661,7 @@ class DisjunctionNode(Node):
     return iter(self.__nodes)
 
   def __repr__(self):
-    return 'OR(%s)' % (', '.join(map(str, self.__nodes)))
+    return 'OR({0!s})'.format((', '.join(map(str, self.__nodes))))
 
   def __eq__(self, other):
     if not isinstance(other, DisjunctionNode):
@@ -701,7 +699,7 @@ def _args_to_val(func, args):
     elif isinstance(arg, gql.Literal):
       val = arg.Get()
     else:
-      raise TypeError('Unexpected arg (%r)' % arg)
+      raise TypeError('Unexpected arg ({0!r})'.format(arg))
     vals.append(val)
   if func == 'nop':
     if len(vals) != 1:
@@ -739,14 +737,12 @@ def _get_prop_from_modelclass(modelclass, name):
     if issubclass(modelclass, model.Expando):
       prop = model.GenericProperty(part)
     else:
-      raise TypeError('Model %s has no property named %r' %
-                      (modelclass._get_kind(), part))
+      raise TypeError('Model {0!s} has no property named {1!r}'.format(modelclass._get_kind(), part))
 
   while more:
     part = more.pop(0)
     if not isinstance(prop, model.StructuredProperty):
-      raise TypeError('Model %s has no property named %r' %
-                      (modelclass._get_kind(), part))
+      raise TypeError('Model {0!s} has no property named {1!r}'.format(modelclass._get_kind(), part))
     maybe = getattr(prop, part, None)
     if isinstance(maybe, model.Property) and maybe._name == part:
       prop = maybe
@@ -761,8 +757,7 @@ def _get_prop_from_modelclass(modelclass, name):
           prop = model.GenericProperty()
           prop._name = name  # Bypass the restriction on dots.
         else:
-          raise KeyError('Model %s has no property named %r' %
-                         (prop._modelclass._get_kind(), part))
+          raise KeyError('Model {0!s} has no property named {1!r}'.format(prop._modelclass._get_kind(), part))
 
   return prop
 
@@ -807,7 +802,7 @@ class Query(object):
             raise TypeError('ancestor cannot be a GQL function other than KEY')
       else:
         if not isinstance(ancestor, model.Key):
-          raise TypeError('ancestor must be a Key; received %r' % (ancestor,))
+          raise TypeError('ancestor must be a Key; received {0!r}'.format(ancestor))
         if not ancestor.id():
           raise ValueError('ancestor cannot be an incomplete key')
         if app is not None:
@@ -820,12 +815,10 @@ class Query(object):
             raise TypeError('namespace/ancestor mismatch')
     if filters is not None:
       if not isinstance(filters, Node):
-        raise TypeError('filters must be a query Node or None; received %r' %
-                        (filters,))
+        raise TypeError('filters must be a query Node or None; received {0!r}'.format(filters))
     if orders is not None:
       if not isinstance(orders, datastore_query.Order):
-        raise TypeError('orders must be an Order instance or None; received %r'
-                        % (orders,))
+        raise TypeError('orders must be an Order instance or None; received {0!r}'.format(orders))
     if default_options is not None:
       if not isinstance(default_options, datastore_rpc.BaseConfiguration):
         raise TypeError('default_options must be a Configuration or None; '
@@ -853,8 +846,7 @@ class Query(object):
         raise TypeError('projection argument cannot be empty')
       if not isinstance(projection, (tuple, list)):
         raise TypeError(
-            'projection must be a tuple, list or None; received %r' %
-            (projection,))
+            'projection must be a tuple, list or None; received {0!r}'.format(projection))
       self._check_properties(self._to_property_names(projection))
       self.__projection = tuple(projection)
 
@@ -864,35 +856,35 @@ class Query(object):
         raise TypeError('group_by argument cannot be empty')
       if not isinstance(group_by, (tuple, list)):
         raise TypeError(
-            'group_by must be a tuple, list or None; received %r' % (group_by,))
+            'group_by must be a tuple, list or None; received {0!r}'.format(group_by))
       self._check_properties(self._to_property_names(group_by))
       self.__group_by = tuple(group_by)
 
   def __repr__(self):
     args = []
     if self.app is not None:
-      args.append('app=%r' % self.app)
+      args.append('app={0!r}'.format(self.app))
     if (self.namespace is not None and
         self.namespace != namespace_manager.get_namespace()):
       # Only show the namespace if set and not the current namespace.
       # (This is similar to what Key.__repr__() does.)
-      args.append('namespace=%r' % self.namespace)
+      args.append('namespace={0!r}'.format(self.namespace))
     if self.kind is not None:
-      args.append('kind=%r' % self.kind)
+      args.append('kind={0!r}'.format(self.kind))
     if self.ancestor is not None:
-      args.append('ancestor=%r' % self.ancestor)
+      args.append('ancestor={0!r}'.format(self.ancestor))
     if self.filters is not None:
-      args.append('filters=%r' % self.filters)
+      args.append('filters={0!r}'.format(self.filters))
     if self.orders is not None:
       # TODO: Format orders better.
       args.append('orders=...')  # PropertyOrder doesn't have a good repr().
     if self.projection:
-      args.append('projection=%r' % (self._to_property_names(self.projection)))
+      args.append('projection={0!r}'.format((self._to_property_names(self.projection))))
     if self.group_by:
-      args.append('group_by=%r' % (self._to_property_names(self.group_by)))
+      args.append('group_by={0!r}'.format((self._to_property_names(self.group_by))))
     if self.default_options is not None:
-      args.append('default_options=%r' % self.default_options)
-    return '%s(%s)' % (self.__class__.__name__, ', '.join(args))
+      args.append('default_options={0!r}'.format(self.default_options))
+    return '{0!s}({1!s})'.format(self.__class__.__name__, ', '.join(args))
 
   def _fix_namespace(self):
     """Internal helper to fix the namespace.
@@ -1076,7 +1068,7 @@ class Query(object):
       preds.append(f)
     for arg in args:
       if not isinstance(arg, Node):
-        raise TypeError('Cannot filter a non-Node argument; received %r' % arg)
+        raise TypeError('Cannot filter a non-Node argument; received {0!r}'.format(arg))
       preds.append(arg)
     if not preds:
       pred = None
@@ -1427,7 +1419,7 @@ class Query(object):
         fixed.append(proj._name)
       else:
         raise TypeError(
-            'Unexpected property (%r); should be string or Property' % (proj,))
+            'Unexpected property ({0!r}); should be string or Property'.format(proj))
     return fixed
 
   def _check_properties(self, fixed, **kwargs):
@@ -1474,8 +1466,8 @@ class Query(object):
         unused.append(i)
     if unused:
       raise datastore_errors.BadArgumentError(
-          'Positional arguments %s were given but not used.' %
-          ', '.join(str(i) for i in unused))
+          'Positional arguments {0!s} were given but not used.'.format(
+          ', '.join(str(i) for i in unused)))
     return self.__class__(kind=self.kind, ancestor=ancestor,
                           filters=filters, orders=self.orders,
                           app=self.app, namespace=self.namespace,
@@ -1538,7 +1530,7 @@ def _gql(query_string, query_class=Query):
       ancestor = _args_to_val(func, args)
       continue
     if op not in _OPS:
-      raise NotImplementedError('Operation %r is not supported.' % op)
+      raise NotImplementedError('Operation {0!r} is not supported.'.format(op))
     for (func, args) in values:
       val = _args_to_val(func, args)
       prop = _get_prop_from_modelclass(modelclass, name)
@@ -1858,11 +1850,10 @@ class _MultiQuery(object):
 
   def __init__(self, subqueries):
     if not isinstance(subqueries, list):
-      raise TypeError('subqueries must be a list; received %r' % subqueries)
+      raise TypeError('subqueries must be a list; received {0!r}'.format(subqueries))
     for subq in subqueries:
       if not isinstance(subq, Query):
-        raise TypeError('Each subquery must be a Query instances; received  %r'
-                        % subq)
+        raise TypeError('Each subquery must be a Query instances; received  {0!r}'.format(subq))
     first_subquery = subqueries[0]
     kind = first_subquery.kind
     orders = first_subquery.orders
@@ -1870,11 +1861,9 @@ class _MultiQuery(object):
       raise ValueError('Subquery kind cannot be missing')
     for subq in subqueries[1:]:
       if subq.kind != kind:
-        raise ValueError('Subqueries must be for a common kind (%s != %s)' %
-                         (subq.kind, kind))
+        raise ValueError('Subqueries must be for a common kind ({0!s} != {1!s})'.format(subq.kind, kind))
       elif subq.orders != orders:
-        raise ValueError('Subqueries must have the same order(s) (%s != %s)' %
-                         (subq.orders, orders))
+        raise ValueError('Subqueries must have the same order(s) ({0!s} != {1!s})'.format(subq.orders, orders))
     # TODO: Ensure that app and namespace match, when we support them.
     self.__subqueries = subqueries
     self.__orders = orders
@@ -2058,7 +2047,7 @@ def _orders_to_orderings(orders):
   if isinstance(orders, datastore_query.CompositeOrder):
     # TODO: What about UTF-8?
     return [(pb.property(), pb.direction()) for pb in orders._to_pbs()]
-  raise ValueError('Bad order: %r' % (orders,))
+  raise ValueError('Bad order: {0!r}'.format(orders))
 
 
 def _ordering_to_order(ordering, modelclass):

--- a/ndb/query_test.py
+++ b/ndb/query_test.py
@@ -507,8 +507,8 @@ class BaseQueryTestMixin(object):
     class Foo(model.Model):
       a = model.StringProperty()
       b = model.StringProperty()
-      c = model.ComputedProperty(lambda ent: '<%s.%s>' % (ent.a, ent.b))
-      d = model.ComputedProperty(lambda ent: '<%s>' % (ent.a,))
+      c = model.ComputedProperty(lambda ent: '<{0!s}.{1!s}>'.format(ent.a, ent.b))
+      d = model.ComputedProperty(lambda ent: '<{0!s}>'.format(ent.a))
     foo = Foo(a='a', b='b')
     foo.put()
     self.assertEqual((foo.a, foo.b, foo.c, foo.d), ('a', 'b', '<a.b>', '<a>'))
@@ -1496,8 +1496,8 @@ class BaseQueryTestMixin(object):
 
   def testGqlAncestor(self):
     key = model.Key('Foo', 42)
-    qry = query.gql("SELECT * FROM Foo WHERE ANCESTOR IS KEY('%s')" %
-                    key.urlsafe())
+    qry = query.gql("SELECT * FROM Foo WHERE ANCESTOR IS KEY('{0!s}')".format(
+                    key.urlsafe()))
     self.assertEqual(qry.kind, 'Foo')
     self.assertEqual(qry.ancestor, key)
     self.assertEqual(qry.filters, None)
@@ -1682,10 +1682,10 @@ class BaseQueryTestMixin(object):
         Bar.gql("WHERE ref = :1").bind(self.joe.key).fetch())
     self.assertEqual(
         [joeref],
-        Bar.gql("WHERE ref = KEY('%s')" % self.joe.key.urlsafe()).fetch())
+        Bar.gql("WHERE ref = KEY('{0!s}')".format(self.joe.key.urlsafe())).fetch())
     self.assertEqual(
         [joeref],
-        Bar.gql("WHERE ref = KEY('Foo', %s)" % self.joe.key.id()).fetch())
+        Bar.gql("WHERE ref = KEY('Foo', {0!s})".format(self.joe.key.id())).fetch())
     self.assertEqual(
         [joeref],
         Bar.gql("WHERE ref = KEY(:1)").bind(self.joe.key.urlsafe()).fetch())
@@ -1704,7 +1704,7 @@ class BaseQueryTestMixin(object):
     moebar.put()
     self.assertEqual(
         [joebar],
-        Bar.gql("WHERE ANCESTOR IS KEY('%s')" % self.joe.key.urlsafe()).fetch())
+        Bar.gql("WHERE ANCESTOR IS KEY('{0!s}')".format(self.joe.key.urlsafe())).fetch())
     self.assertEqual(
         [joebar],
         Bar.gql("WHERE ANCESTOR IS :1").bind(self.joe.key).fetch())
@@ -1954,7 +1954,7 @@ class BaseQueryTestMixin(object):
 
       class M(ndb.Model):
         a = ndb.IntegerProperty()
-      ms = [M(a=i, id='%04d' % i) for i in range(33)]
+      ms = [M(a=i, id='{0:04d}'.format(i)) for i in range(33)]
       ks = ndb.put_multi(ms)
       q = M.query().order(M.a)
       xs = fetch(q, 9)

--- a/ndb/tasklets_test.py
+++ b/ndb/tasklets_test.py
@@ -208,19 +208,19 @@ class TaskletTests(test_utils.NDBTest):
     t0, t1 = log
     dt = t1 - t0
     self.assertTrue(0.08 <= dt <= 0.12,
-                    'slept too long or too short: dt=%.03f' % dt)
+                    'slept too long or too short: dt={0:.03f}'.format(dt))
 
   def testMultiFuture(self):
     @tasklets.tasklet
     def foo(dt):
       yield tasklets.sleep(dt)
-      raise tasklets.Return('foo-%s' % dt)
+      raise tasklets.Return('foo-{0!s}'.format(dt))
 
     @tasklets.tasklet
     def bar(n):
       for _ in range(n):
         yield tasklets.sleep(0.01)
-      raise tasklets.Return('bar-%d' % n)
+      raise tasklets.Return('bar-{0:d}'.format(n))
     bar5 = bar(5)
     futs = [foo(0.05), foo(0.01), foo(0.03), bar(3), bar5, bar5]
     mfut = tasklets.MultiFuture()

--- a/ndb/test_utils.py
+++ b/ndb/test_utils.py
@@ -131,8 +131,7 @@ class NDBTest(NDBBaseTest):
       if not hasattr(self.the_module, name):
         undefined.append(name)
     self.assertFalse(undefined,
-                     '%s.__all__ has some names that are not defined: %s' %
-                     (modname, undefined))
+                     '{0!s}.__all__ has some names that are not defined: {1!s}'.format(modname, undefined))
     module_type = type(self.the_module)
     unlisted = []
     for name in dir(self.the_module):
@@ -142,8 +141,7 @@ class NDBTest(NDBBaseTest):
           if name not in self.the_module.__all__:
             unlisted.append(name)
     self.assertFalse(unlisted,
-                     '%s defines some names that are not in __all__: %s' %
-                     (modname, unlisted))
+                     '{0!s} defines some names that are not in __all__: {1!s}'.format(modname, unlisted))
 
   def HRTest(self):
     ds_stub = self.testbed.get_stub('datastore_v3')

--- a/ndb/utils.py
+++ b/ndb/utils.py
@@ -132,7 +132,7 @@ def code_info(code, lineno=None):
   filename = os.path.basename(code.co_filename)
   if lineno is None:
     lineno = code.co_firstlineno
-  return '%s(%s:%s)' % (funcname, filename, lineno)
+  return '{0!s}({1!s}:{2!s})'.format(funcname, filename, lineno)
 
 
 def positional(max_pos_args):
@@ -155,8 +155,7 @@ def positional(max_pos_args):
         if max_pos_args != 1:
           plural_s = 's'
         raise TypeError(
-            '%s() takes at most %d positional argument%s (%d given)' %
-            (wrapped.__name__, max_pos_args, plural_s, len(args)))
+            '{0!s}() takes at most {1:d} positional argument{2!s} ({3:d} given)'.format(wrapped.__name__, max_pos_args, plural_s, len(args)))
       return wrapped(*args, **kwds)
     return positional_wrapper
   return positional_decorator

--- a/samples/columbus.py
+++ b/samples/columbus.py
@@ -36,7 +36,7 @@ class FuzzyDate(object):
     self.last = last or first
 
   def __repr__(self):
-    return 'FuzzyDate(%r, %r)' % (self.first, self.last)
+    return 'FuzzyDate({0!r}, {1!r})'.format(self.first, self.last)
 
 
 class FuzzyDateModel(Model):

--- a/samples/custom.py
+++ b/samples/custom.py
@@ -52,10 +52,10 @@ class Flexidate(object):
 
   def __repr__(self):
     if self.__fuzz == 1:
-      return 'Flexidate<%d-%d-%d>' % (self.__date.year, self.__date.month,
+      return 'Flexidate<{0:d}-{1:d}-{2:d}>'.format(self.__date.year, self.__date.month,
                                       self.__date.day)
     else:
-      return 'Flexidate<%d-%d-%d+%d>' % (self.__date.year, self.__date.month,
+      return 'Flexidate<{0:d}-{1:d}-{2:d}+{3:d}>'.format(self.__date.year, self.__date.month,
                                          self.__date.day, self.__fuzz)
 
   @property
@@ -200,12 +200,11 @@ class FlexidateProperty(CustomProperty):
     )
 
   def __repr__(self):
-    return ('FlexidateProperty(%r, %r, %r)' %
-            (self._name, self._repeated, self._indexed))
+    return ('FlexidateProperty({0!r}, {1!r}, {2!r})'.format(self._name, self._repeated, self._indexed))
 
   def _validate(self, value):
     if not isinstance(value, Flexidate):
-      raise TypeError('expected Flexidate, got %r' % (value,))
+      raise TypeError('expected Flexidate, got {0!r}'.format(value))
 
 
 class Actor(Model):
@@ -242,19 +241,19 @@ def main():
   q = Actor.query(Actor.born.start == datetime.date(1956, 1, 1))
   print 'q =', q
   for i, res in enumerate(q):
-    print '%2d: %s' % (i, res)
+    print '{0:2d}: {1!s}'.format(i, res)
   q = Actor.query(Actor.born == Flexidate(datetime.date(1956, 1, 1), 366))
   print 'q =', q
   for i, res in enumerate(q):
-    print '%2d: %s' % (i, res)
+    print '{0:2d}: {1!s}'.format(i, res)
   q = Actor.query(Actor.born.fuzz >= 31)
   print 'q =', q
   for i, res in enumerate(q):
-    print '%2d: %s' % (i, res)
+    print '{0:2d}: {1!s}'.format(i, res)
   q = Actor.query(Actor.events.fuzz == 366)
   print 'q =', q
   for i, res in enumerate(q):
-    print '%2d: %s' % (i, res)
+    print '{0:2d}: {1!s}'.format(i, res)
 
   tb.deactivate()
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -65,7 +65,7 @@ def main():
     except Exception:
       pass
   prof = cProfile.Profile()
-  prof = prof.runctx('bench(%d)' % n, globals(), locals())
+  prof = prof.runctx('bench({0:d})'.format(n), globals(), locals())
   stats = pstats.Stats(prof)
   stats.strip_dirs()
   stats.sort_stats('time')  # 'time', 'cumulative' or 'calls'

--- a/tests/dbench.py
+++ b/tests/dbench.py
@@ -59,7 +59,7 @@ def bench(n):
 
 def profiler(func, n):
   prof = cProfile.Profile()
-  prof = prof.runctx('%s(%d)' % (func.__name__, n), globals(), locals())
+  prof = prof.runctx('{0!s}({1:d})'.format(func.__name__, n), globals(), locals())
   stats = pstats.Stats(prof)
   stats.strip_dirs()
   stats.sort_stats('time')  # 'time', 'cumulative' or 'calls'

--- a/tests/gettaskletrace.py
+++ b/tests/gettaskletrace.py
@@ -41,7 +41,7 @@ def cause_problem():
     yield ctx.get(key)  # Trigger get_tasklet that does not complete...
     yield ctx.delete(key)  # ... by the time this delete_tasklet starts.
     a = yield ctx.get(key)
-    assert a is None, '%r is not None' % a
+    assert a is None, '{0!r} is not None'.format(a)
 
   problem_tasklet().check_success()
   print 'No problem yet...'

--- a/tests/keybench.py
+++ b/tests/keybench.py
@@ -72,7 +72,7 @@ def main():
     except Exception:
       pass
   prof = cProfile.Profile()
-  prof = prof.runctx('bench(%d)' % n, globals(), locals())
+  prof = prof.runctx('bench({0:d})'.format(n), globals(), locals())
   stats = pstats.Stats(prof)
   stats.strip_dirs()
   stats.sort_stats('time')  # 'time', 'cumulative' or 'calls'

--- a/tests/kobench.py
+++ b/tests/kobench.py
@@ -58,7 +58,7 @@ def bench(n):
 
 def profiler(func, n):
   prof = cProfile.Profile()
-  prof = prof.runctx('%s(%d)' % (func.__name__, n), globals(), locals())
+  prof = prof.runctx('{0!s}({1:d})'.format(func.__name__, n), globals(), locals())
   stats = pstats.Stats(prof)
   stats.strip_dirs()
   stats.sort_stats('time')  # 'time', 'cumulative' or 'calls'

--- a/tests/mttest.py
+++ b/tests/mttest.py
@@ -43,7 +43,7 @@ def main():
 def one_thread(i, num):
   ##sys.stdout.write('eventloop = 0x%x\n' % id(eventloop.get_event_loop()))
   x = yield fibonacci(num)
-  sys.stdout.write('%d: %d --> %d\n' % (i, num, x))
+  sys.stdout.write('{0:d}: {1:d} --> {2:d}\n'.format(i, num, x))
 
 
 @tasklets.tasklet

--- a/tests/putbench.py
+++ b/tests/putbench.py
@@ -82,7 +82,7 @@ def timer(func, people):
   t0 = time.time()
   func(people)
   t1 = time.time()
-  print '%.3f seconds' % (t1 - t0)
+  print '{0:.3f} seconds'.format((t1 - t0))
 
 
 def main(k=0):

--- a/tests/race.py
+++ b/tests/race.py
@@ -145,7 +145,7 @@ def subverting_aries_fix():
   assert pb3 is not context._LOCKED, 'Received _LOCKED value'
   if pb3 is not None:
     ent3 = ctx._conn.adapter.pb_to_entity(pb3)
-    assert ent3 == ent2, 'stale value in memcache; %r != %r' % (ent3, ent2)
+    assert ent3 == ent2, 'stale value in memcache; {0!r} != {1!r}'.format(ent3, ent2)
 
   # Finally check the high-level API.
   ent4 = key.get()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:datastore-ndb-python?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:datastore-ndb-python?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
